### PR TITLE
Add syntax hilighting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,6 +39,15 @@ name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -162,6 +177,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,9 +281,20 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "syntect",
  "termcolor",
  "url",
  "walkdir",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -621,6 +656,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-wrap"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
+dependencies = [
+ "safemem",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +696,15 @@ name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -688,10 +747,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
+
+[[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "openssl"
@@ -811,6 +901,20 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
+name = "plist"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd39bc6cdc9355ad1dc5eeedefee696bb35c34caf21768741e81826c0bbd7225"
+dependencies = [
+ "base64",
+ "indexmap",
+ "line-wrap",
+ "serde",
+ "time",
+ "xml-rs",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -942,6 +1046,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "safemem"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
 
 [[package]]
 name = "same-file"
@@ -1098,6 +1208,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c454c27d9d7d9a84c7803aaa3c50cd088d2906fe3c6e42da3209aa623576a8"
+dependencies = [
+ "bincode",
+ "bitflags",
+ "flate2",
+ "fnv",
+ "lazy_static",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1277,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
 ]
 
 [[package]]
@@ -1491,4 +1635,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d7d3948613f75c98fd9328cfdcc45acc4d360655289d0a7d4ec931392200a3"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ lazy_static = "1.4"
 handlebars = "4.3"
 walkdir = "2.3"
 git2 = "0.15"
+syntect = "5.0"
 
 [build-dependencies]
 built = { version = "0.5" }

--- a/examples/post_request_with_body.yml
+++ b/examples/post_request_with_body.yml
@@ -7,6 +7,7 @@ headers:
   Accept: application/vnd.github+json
   # Here is an example of a header that uses variable substitution
   Authorization: token {{GITHUB_TOKEN}}
+  content-type: application/json
 
 body: >
   {

--- a/examples/request_with_json_response.yml
+++ b/examples/request_with_json_response.yml
@@ -1,0 +1,5 @@
+method: GET
+url: https://api.github.com/licenses/mit
+headers:
+  authorization: Bearer {{GITHUB_TOKEN}}
+  accept: application/json

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,5 +1,3 @@
-use std::fmt::format;
-
 use syntect::{
     easy::HighlightLines,
     highlighting::{Style, Theme, ThemeSet},
@@ -18,7 +16,7 @@ pub fn formatters() -> Vec<Box<dyn ContentFormatter>> {
     vec![
         Box::new(JsonPretty::new()),
         Box::new(JsonSyntax::new(theme.clone())),
-        Box::new(XmlSyntax::new(theme.clone())),
+        Box::new(XmlSyntax::new(theme)),
     ]
 }
 
@@ -46,7 +44,7 @@ impl ContentFormatter for JsonSyntax {
 
     fn format(&self, content: String) -> Result<String, String> {
         let syntax = self.syntax_set.find_syntax_by_extension("json").unwrap();
-        let mut high = HighlightLines::new(&syntax, &self.theme);
+        let mut high = HighlightLines::new(syntax, &self.theme);
         let mut out: Vec<String> = Vec::with_capacity(512);
         for line in LinesWithEndings::from(&content) {
             let ranges: Vec<(Style, &str)> = high.highlight_line(line, &self.syntax_set).unwrap();
@@ -104,7 +102,7 @@ impl ContentFormatter for XmlSyntax {
 
     fn format(&self, content: String) -> Result<String, String> {
         let syntax = self.syntax_set.find_syntax_by_extension("xml").unwrap();
-        let mut high = HighlightLines::new(&syntax, &self.theme);
+        let mut high = HighlightLines::new(syntax, &self.theme);
         let mut out: Vec<String> = Vec::with_capacity(512);
         for line in LinesWithEndings::from(&content) {
             let ranges: Vec<(Style, &str)> = high.highlight_line(line, &self.syntax_set).unwrap();

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,3 +1,5 @@
+use std::fmt::format;
+
 use syntect::{
     easy::HighlightLines,
     highlighting::{Style, Theme, ThemeSet},
@@ -72,7 +74,8 @@ impl ContentFormatter for JsonPretty {
     }
 
     fn format(&self, content: String) -> Result<String, String> {
-        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+        let json: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|e| format!("Unable to parse body as JSON: {:?}", e))?;
         Ok(serde_json::to_string_pretty(&json).unwrap())
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,72 @@
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{Style, ThemeSet},
+    parsing::SyntaxSet,
+    util::{as_24_bit_terminal_escaped, LinesWithEndings},
+};
+
+pub trait ContentFormatter {
+    fn accept(&self, content_type: Option<&str>) -> bool;
+    fn format(&self, content: String) -> Result<String, String>;
+}
+
+pub fn formatters() -> Vec<Box<dyn ContentFormatter>> {
+    vec![Box::new(JsonPretty::new()), Box::new(JsonSyntax::new())]
+}
+
+pub struct JsonSyntax {
+    syntax_set: SyntaxSet,
+    theme: ThemeSet,
+}
+
+impl JsonSyntax {
+    pub fn new() -> JsonSyntax {
+        JsonSyntax {
+            syntax_set: SyntaxSet::load_defaults_newlines(),
+            theme: ThemeSet::load_defaults(),
+        }
+    }
+}
+
+impl ContentFormatter for JsonSyntax {
+    fn accept(&self, content_type: Option<&str>) -> bool {
+        match content_type {
+            Some(ct) => ct.starts_with("application/json"),
+            None => false,
+        }
+    }
+
+    fn format(&self, content: String) -> Result<String, String> {
+        let syntax = self.syntax_set.find_syntax_by_extension("json").unwrap();
+        let mut high = HighlightLines::new(&syntax, &self.theme.themes["base16-ocean.dark"]);
+        let mut out: Vec<String> = Vec::with_capacity(512);
+        for line in LinesWithEndings::from(&content) {
+            let ranges: Vec<(Style, &str)> = high.highlight_line(line, &self.syntax_set).unwrap();
+            let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
+            out.push(escaped);
+        }
+        Ok(out.as_slice().join(""))
+    }
+}
+
+pub struct JsonPretty;
+
+impl JsonPretty {
+    pub fn new() -> JsonPretty {
+        JsonPretty
+    }
+}
+
+impl ContentFormatter for JsonPretty {
+    fn accept(&self, content_type: Option<&str>) -> bool {
+        match content_type {
+            Some(ct) => ct.starts_with("application/json"),
+            None => false,
+        }
+    }
+
+    fn format(&self, content: String) -> Result<String, String> {
+        let json: serde_json::Value = serde_json::from_str(&content).unwrap();
+        Ok(serde_json::to_string_pretty(&json).unwrap())
+    }
+}

--- a/src/http.rs
+++ b/src/http.rs
@@ -10,6 +10,7 @@ use crate::headers::Appendable;
 
 #[derive(Debug, Deserialize)]
 pub struct HttpRequest {
+    #[serde(alias = "method")]
     verb: Verb,
     url: String,
     body: Option<String>,

--- a/src/io.rs
+++ b/src/io.rs
@@ -45,3 +45,10 @@ pub fn write_body(stream: &mut StandardStream, content_type: Option<&str>, body:
     };
     writeln(stream, &format!("\n{body}"));
 }
+
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{Style, ThemeSet},
+    parsing::SyntaxSet,
+    util::{as_24_bit_terminal_escaped, LinesWithEndings},
+};

--- a/src/io.rs
+++ b/src/io.rs
@@ -46,9 +46,3 @@ pub fn write_body(stream: &mut StandardStream, content_type: Option<&str>, body:
     writeln(stream, &format!("\n{body}"));
 }
 
-use syntect::{
-    easy::HighlightLines,
-    highlighting::{Style, ThemeSet},
-    parsing::SyntaxSet,
-    util::{as_24_bit_terminal_escaped, LinesWithEndings},
-};

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,11 +99,12 @@ fn exec() -> Result<(), FireError> {
             for (k, v) in &req_headers {
                 writeln_spec(&mut stdout, &format!("{}: {:?}", k.as_str(), v), &spec);
             }
+            if request.body().is_some() {
+                writeln(&mut stdout, "");
+            }
         }
 
         if let Some(body) = request.body() {
-            writeln(&mut stdout, "");
-
             let content: String = formatters
                 .iter()
                 .filter(|fmt| fmt.accept(content_type))
@@ -186,6 +187,9 @@ fn exec() -> Result<(), FireError> {
                 None => log::warn!("Found header key that was empty or unresolvable"),
             }
         }
+        if !body.is_empty() {
+            io::writeln(&mut stdout, "");
+        }
     }
 
     if !body.is_empty() {
@@ -195,9 +199,10 @@ fn exec() -> Result<(), FireError> {
             .filter(|fmt| fmt.accept(content_type))
             .fold(body, |content, fmt| fmt.format(content).unwrap());
 
-        io::writeln(&mut stdout, "");
         io::write(&mut stdout, &content);
-        io::writeln(&mut stdout, "");
+        if !content.ends_with('\n') {
+            io::writeln(&mut stdout, "");
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,8 @@ fn exec() -> Result<(), FireError> {
         Err(e) => return Err(FireError::Other(e.to_string())),
     };
 
+    log::debug!("Body of response:\n{body}");
+
     let status_color: Option<Color> = match status.as_u16() {
         200..=299 => Some(Color::Green),
         400..=499 => Some(Color::Yellow),


### PR DESCRIPTION
Closes #1 

Adds support for syntax highlighting for request (if printed) and response body. Currently only JSON and XML is supported, but the feature is built so it is easy to extend to other languages or formats in the future.